### PR TITLE
Yoyoyo

### DIFF
--- a/commonware/response/middleware.py
+++ b/commonware/response/middleware.py
@@ -75,8 +75,8 @@ class GraphiteRequestTimingMiddleware(object):
         if not inspect.isfunction(view_func):
             view = view.__class__
         try:
-            request._statsd_timing = 'view.{n}.{v}.{m}'.format(
-                n=view.__module__, v=view.__name__, m=request.method)
+            request._view_module = view.__module__
+            request._view_name = view.__name__
             request._start_time = time.time()
         except AttributeError:
             pass
@@ -89,6 +89,10 @@ class GraphiteRequestTimingMiddleware(object):
         self._record_time(request)
 
     def _record_time(self, request):
-        if hasattr(request, '_statsd_timing'):
+        if hasattr(request, '_start_time'):
             ms = int((time.time() - request._start_time) * 1000)
-            statsd.timing(request._statsd_timing, ms)
+            data = dict(module=request._view_module, name=request._view_name,
+                        method=request.method)
+            statsd.timing('view.{module}.{name}.{method}'.format(**data), ms)
+            statsd.timing('view.{module}.{method}'.format(**data), ms)
+            statsd.timing('view.{method}'.format(**data), ms)


### PR DESCRIPTION
r?(rlr,jsocol)

The first commit is so we know how many authenticated users we have. We're expecting it to go up as marketplace rolls out and requires you to log in to add apps. That's going to hurt our zeus caching, so we want numbers.

The second one makes it easier to find out the average response time for all GET requests, and the average time for all the addons views. I can't figure out how to get graphite's wildcard aggregates to show me the number. If you guys know how we can disregard that commit.
