### PR TITLE
Increase default STS_MAX_AGE from 30 days to 1 year to allow inclusion into HSTS preload list

### DIFF
--- a/commonware/response/middleware.py
+++ b/commonware/response/middleware.py
@@ -42,14 +42,14 @@ class RobotsTagHeader(object):
 class StrictTransportMiddleware(object):
     """
     Set the Strict-Transport-Security header on responses. Use the
-    STS_MAX_AGE setting to control the max-age value. (Default: 1 month.)
+    STS_MAX_AGE setting to control the max-age value. (Default: 1 year.)
     Use the STS_SUBDOMAINS boolean to add includeSubdomains.
     (Default: False.)
     """
 
     def process_response(self, request, response):
         if request.is_secure():
-            age = getattr(settings, 'STS_MAX_AGE', 2592000)  # 30 days.
+            age = getattr(settings, 'STS_MAX_AGE', 31536000)  # 365 days.
             subdomains = getattr(settings, 'STS_SUBDOMAINS', False)
             val = 'max-age=%d' % age
             if subdomains:

--- a/commonware/response/tests.py
+++ b/commonware/response/tests.py
@@ -35,7 +35,7 @@ def test_sts_middleware():
     assert 'Strict-Transport-Security' not in resp
     resp = _make_resp(middleware.StrictTransportMiddleware, secure=True)
     assert 'Strict-Transport-Security' in resp
-    eq_('max-age=2592000', resp['Strict-Transport-Security'])
+    eq_('max-age=31536000', resp['Strict-Transport-Security'])
 
 
 @mock.patch.object(settings._wrapped, 'STS_SUBDOMAINS', True)


### PR DESCRIPTION
Firefox requires that any built-in HSTS preloads have a max-age of at least 18 weeks (10886400 seconds), as per https://wiki.mozilla.org/Privacy/Features/HSTS_Preload_List. Since that's already over 4 months, make the default 1 year (31536000 seconds).

If this ever becomes a problem, a max-age of 0 can be used as a knock-out entry to override any built-in or existing browser settings.
